### PR TITLE
Modify principle count calculation in verify.sh

### DIFF
--- a/scripts/verify.sh
+++ b/scripts/verify.sh
@@ -93,7 +93,7 @@ echo ""
 # --- Principles ---
 echo "📜 Principles:"
 if [ -f "$WORKSPACE/MEMORY.md" ]; then
-  P_COUNT=$(grep -c "^### P[0-9]" "$WORKSPACE/MEMORY.md" 2>/dev/null || echo "0")
+  P_COUNT=$(grep -c "^### P[0-9]" "$WORKSPACE/MEMORY.md" 2>/dev/null | tr -d '\n' || echo "0")
   if [ "$P_COUNT" -ge 7 ]; then
     check "$P_COUNT principles found in MEMORY.md" "ok"
   elif [ "$P_COUNT" -ge 1 ]; then


### PR DESCRIPTION
Change the way principle count is calculated by removing newline characters from the grep output.

Fix #2 